### PR TITLE
bugfix/AO-36

### DIFF
--- a/Apto/Plugins/MaterialPickerElement/Application/Core/Query/Pool/PoolQueryHandler.php
+++ b/Apto/Plugins/MaterialPickerElement/Application/Core/Query/Pool/PoolQueryHandler.php
@@ -147,8 +147,7 @@ class PoolQueryHandler implements QueryHandlerInterface
 
         foreach ($items['data'] as $item) {
 
-            if (array_key_exists('conditionSets', $item['material']) && count($item['material']['conditionSets']) > 0) {
-
+            if (array_key_exists('conditionSets', $item['material']) && !empty($item['material']['conditionSets'])) {
                 $productConditionsResult = $this->productConditionSetFinder->findByIdsForProduct($query->getProductId(), $item['material']['conditionSets']);
 
                 if ($this->conditionSetsFulfilled($productConditionsResult['data'],


### PR DESCRIPTION
Small Bug that caused the if condition in the handleFindPoolItemsFiltered function to return an error since $item['material']['conditionSets'] returns false instead of an empty array when no conditions are set.